### PR TITLE
[security] redact phone number in logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ WARNING: This is a development server. Do not use it in a production deployment.
 Press CTRL+C to quit
 Received SMS:
 SIM: 1
-From: 6505551212
+From: ******1212
 Message: Android is always a sweet treat!
 Received at: 2025-04-15 15:50:56+07:00
 127.0.0.1 - - [15/Apr/2025 15:50:59] "POST /webhook/sms-received HTTP/1.1" 200 -

--- a/main.py
+++ b/main.py
@@ -57,7 +57,15 @@ def create_app():
 
         print("Received SMS:")
         print(f"SIM: {payload.payload.sim_number}")
-        print(f"From: {payload.payload.phone_number}")
+        phone_number = payload.payload.phone_number
+        masked_phone_number = (
+            ("*" * len(phone_number))
+            if phone_number and len(phone_number) <= 4
+            else (("*" * (len(phone_number) - 4)) + phone_number[-4:])
+            if phone_number
+            else "<redacted>"
+        )
+        print(f"From: {masked_phone_number}")
         print(f"Message: {payload.payload.message}")
         print(f"Received at: {payload.payload.received_at}")
 
@@ -78,7 +86,7 @@ def register_webhook() -> None | str:
 
     with httpx.Client() as client:
         response = client.post(
-            f"{current_app.config["SMS_GATE_API_URL"]}/webhooks",
+            f"{current_app.config['SMS_GATE_API_URL']}/webhooks",
             auth=(
                 current_app.config["SMS_GATE_API_USERNAME"],
                 current_app.config["SMS_GATE_API_PASSWORD"],
@@ -106,14 +114,14 @@ def unregister_webhook(webhook_id: str | None):
 
     with httpx.Client() as client:
         response = client.delete(
-            f"{current_app.config['SMS_GATE_API_URL']}/webhooks/{current_app.config["WEBHOOK_ID"]}",
+            f"{current_app.config['SMS_GATE_API_URL']}/webhooks/{current_app.config['WEBHOOK_ID']}",
             auth=(
                 current_app.config["SMS_GATE_API_USERNAME"],
                 current_app.config["SMS_GATE_API_PASSWORD"],
             ),
         )
         response.raise_for_status()
-        print(f"Unregistered webhook ID: {current_app.config["WEBHOOK_ID"]}")
+        print(f"Unregistered webhook ID: {current_app.config['WEBHOOK_ID']}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Potential fix for [https://github.com/android-sms-gateway/example-webhooks-flask/security/code-scanning/1](https://github.com/android-sms-gateway/example-webhooks-flask/security/code-scanning/1)

To fix this without changing core behavior, keep the logging statement but mask the phone number before printing (for example, reveal only the last 2–4 digits). This preserves observability/debug value while preventing full sensitive data disclosure in logs.

Best concrete change in `main.py`:
- In `handle_sms_webhook()` at the logging block (lines around 58–63), replace:
  - `print(f"From: {payload.payload.phone_number}")`
- With a masked version:
  - compute `masked_phone_number` from `payload.payload.phone_number`
  - print masked value instead of raw value

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privacy in SMS webhook logging by masking incoming phone numbers, showing only the last 4 digits or a redacted placeholder when missing.
  * Kept webhook validation and response behavior unchanged.
* **Documentation**
  * Updated the README “Usage” sample output to reflect masked `From:` values instead of full phone numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->